### PR TITLE
Add a verb to `it` in `@example` in the document

### DIFF
--- a/docs/modules/ROOT/pages/cops_committee.adoc
+++ b/docs/modules/ROOT/pages/cops_committee.adoc
@@ -19,14 +19,14 @@ Check for validation of redundant response HTTP status codes.
 [source,ruby]
 ----
 # bad
-it 'something' do
+it 'does something' do
   subject
   expect(response).to have_http_status 400
   assert_schema_conform(400)
 end
 
 # good
-it 'something' do
+it 'does something' do
   subject
   assert_schema_conform(400)
 end
@@ -52,13 +52,13 @@ where the expected response status code is required.
 [source,ruby]
 ----
 # bad
-it 'something' do
+it 'does something' do
   subject
   assert_schema_conform
 end
 
 # good
-it 'something' do
+it 'does something' do
   subject
   assert_schema_conform(200)
 end

--- a/lib/rubocop/cop/committee/redundant_response_status_assertions.rb
+++ b/lib/rubocop/cop/committee/redundant_response_status_assertions.rb
@@ -7,14 +7,14 @@ module RuboCop
       #
       # @example
       #   # bad
-      #   it 'something' do
+      #   it 'does something' do
       #     subject
       #     expect(response).to have_http_status 400
       #     assert_schema_conform(400)
       #   end
       #
       #   # good
-      #   it 'something' do
+      #   it 'does something' do
       #     subject
       #     assert_schema_conform(400)
       #   end

--- a/lib/rubocop/cop/committee/unspecified_expected_status.rb
+++ b/lib/rubocop/cop/committee/unspecified_expected_status.rb
@@ -8,13 +8,13 @@ module RuboCop
       #
       # @example
       #   # bad
-      #   it 'something' do
+      #   it 'does something' do
       #     subject
       #     assert_schema_conform
       #   end
       #
       #   # good
-      #   it 'something' do
+      #   it 'does something' do
       #     subject
       #     assert_schema_conform(200)
       #   end

--- a/spec/rubocop/cop/committee/redundant_response_status_assertions_spec.rb
+++ b/spec/rubocop/cop/committee/redundant_response_status_assertions_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Committee::RedundantResponseStatusAssertions, :conf
   it "registers an offense and autocorrects when using `assert_schema_conform` " \
      "with argument and `have_http_status`" do
     expect_offense(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         expect(response).to have_http_status(400)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove redundant HTTP response status code validation.
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::Committee::RedundantResponseStatusAssertions, :conf
     RUBY
 
     expect_correction(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         do_something
         assert_schema_conform(400)
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Committee::RedundantResponseStatusAssertions, :conf
   it "registers an offense and autocorrects when using `assert_response_schema_confirm` " \
      "with argument and `have_http_status`" do
     expect_offense(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         expect(response).to have_http_status 400
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove redundant HTTP response status code validation.
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Cop::Committee::RedundantResponseStatusAssertions, :conf
     RUBY
 
     expect_correction(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         do_something
         assert_response_schema_confirm 400
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::Committee::RedundantResponseStatusAssertions, :conf
   it "does not register an offense when using `assert_schema_conform` " \
      "with no argument and `have_http_status`" do
     expect_no_offenses(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         do_something
         expect(response).to have_http_status(400)

--- a/spec/rubocop/cop/committee/unspecified_expected_status_spec.rb
+++ b/spec/rubocop/cop/committee/unspecified_expected_status_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Committee::UnspecifiedExpectedStatus, :config do
   it "registers an offense and autocorrects when using `assert_schema_conform` " \
      "with no argument and `have_http_status`" do
     expect_offense(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         expect(response).to have_http_status 400
         do_something
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::Committee::UnspecifiedExpectedStatus, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         expect(response).to have_http_status 400
         do_something
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Committee::UnspecifiedExpectedStatus, :config do
   it "registers an offense when using `assert_schema_conform` " \
      "with no argument" do
     expect_offense(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         do_something
         assert_schema_conform
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Committee::UnspecifiedExpectedStatus, :config do
   it "does not register an offense and autocorrects when using `assert_schema_conform` " \
      "with http status code" do
     expect_no_offenses(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         assert_schema_conform(400)
       end
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Committee::UnspecifiedExpectedStatus, :config do
   it "registers an offense and autocorrects when using `assert_response_schema_confirm` " \
      "with no argument" do
     expect_offense(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         expect(response).to have_http_status 400
         do_something
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::Committee::UnspecifiedExpectedStatus, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         expect(response).to have_http_status 400
         do_something
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Committee::UnspecifiedExpectedStatus, :config do
   it "does not register an offense when using `assert_response_schema_confirm` " \
      "with http status code" do
     expect_no_offenses(<<~RUBY)
-      it 'something' do
+      it 'does something' do
         subject
         assert_response_schema_confirm(400)
       end


### PR DESCRIPTION
RSpec also recommends it.
Ref: https://relishapp.com/rspec/rspec-core/v/3-12/docs/example-groups/basic-structure-describe-it#one-group,-one-example