### PR TITLE
Drop Ruby 2.6 runtime support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ruby:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Mdformat
         uses: ydah/mdformat-action@main
         with:
+          file_or_dir:
+            CODE_OF_CONDUCT.md CHANGELOG.md README.md .github/PULL_REQUEST_TEMPLATE.md .github/CONTRIBUTING.md .github/ISSUE_TEMPLATE/feature_request.md .github/ISSUE_TEMPLATE/bug_report.md MIT-LICENSE.md
           number: true
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   SuggestExtensions: false
 
 Layout/LineLength:

--- a/changelog/change_drop_ruby_2_6_runtime_support.md
+++ b/changelog/change_drop_ruby_2_6_runtime_support.md
@@ -1,0 +1,1 @@
+- [#4](https://github.com/rubocop/rubocop-committee/pull/4): Drop Ruby 2.6 runtime support. ([@ydah])

--- a/rubocop-committee.gemspec
+++ b/rubocop-committee.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   DESCRIPTION
   spec.homepage = "https://github.com/ydah/rubocop-committee"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/spec/project/changelog_spec.rb
+++ b/spec/project/changelog_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe "CHANGELOG.md" do
 
     describe "link to related issue on github" do
       let(:issues) do
-        entries.map do |entry|
+        entries.filter_map do |entry|
           entry.match(/\[(?<number>[#\d]+)\]\((?<url>[^)]+)\)/)
-        end.compact
+        end
       end
 
       it "has an issue number prefixed with #" do


### PR DESCRIPTION
This PR drops Ruby 2.6 runtime support. The next release will be the time to drop Ruby 2.6 support:

https://www.ruby-lang.org/en/downloads/branches/
https://docs.rubocop.org/rubocop/compatibility.html#support-matrix

Follow up: https://github.com/rubocop/rubocop/pull/11791

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Wrote [good commit messages][1].
- [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-committee/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).